### PR TITLE
ImageSolver: Changed the behavior of the seed parameters when processing a list of files

### DIFF
--- a/src/scripts/AdP/AnnotateImage.js
+++ b/src/scripts/AdP/AnnotateImage.js
@@ -30,6 +30,8 @@
 /*
    Changelog:
 
+   1.9.1:* Added test for too big images (>0.5GigaPixels)
+
    1.9:  * Use downloaded catalogs
 
    1.8.5:* Fixed: When the script was executed from the console it ignored the
@@ -184,7 +186,7 @@
 #include <pjsr/SampleType.jsh>
 #include <pjsr/ColorSpace.jsh>
 
-#define VERSION "1.9"
+#define VERSION "1.9.1"
 #define TITLE "Annotate Image"
 #define SETTINGS_MODULE "ANNOT"
 
@@ -2294,6 +2296,9 @@ function AnnotationEngine()
       if (this.metadata.epoch)
          this.epoch = this.metadata.epoch;
       this.metadata.Print();
+
+      if(this.metadata.width * this.metadata.height *4 >= 2*1024*1024*1024)
+         throw Error("The script can not annotate images bigger than 536,870,912 pixels");
    };
 
    this.SetDefaults = function ()
@@ -2532,6 +2537,8 @@ function AnnotationEngine()
          else
             bmp.fill(0x00000000);
          var g = new VectorGraphics(bmp);
+         if (!g.isPainting)
+            throw Error("The script can not draw on the image");
 
          console.writeln("Rendering annotation");
          this.RenderGraphics(g, width, height);
@@ -2620,6 +2627,8 @@ function AnnotationEngine()
       else
          bmp.fill(0x00000000);
       var g = new VectorGraphics(bmp);
+      if (!g.isPainting)
+         throw Error("The script can not draw on the image");
 
       console.writeln("Rendering annotation");
       this.RenderGraphics(g, width, height);

--- a/src/scripts/AdP/AperturePhotometry.js
+++ b/src/scripts/AdP/AperturePhotometry.js
@@ -2426,6 +2426,11 @@ function PhotometryEngine(w)
       console.writeln("Generating detected stars image");
       var width = window.mainView.image.width;
       var height = window.mainView.image.height;
+      if (width * height * 4 >= 2 * 1024 * 1024 * 1024)
+      {
+         console.warningln("Cannot draw the image: The size is too big");
+         return;
+      }
 
       var newid = window.mainView.fullId + suffix;
 

--- a/src/scripts/AdP/ImageSolver.js
+++ b/src/scripts/AdP/ImageSolver.js
@@ -1897,6 +1897,11 @@ function ImageSolver()
       if(!stars)
          return;
       console.writeln("Creating error map");
+      if (metadata.width * metadata.height * 4 >= 2 * 1024 * 1024 * 1024)
+      {
+         console.warningln("Cannot draw the image: The size is too big");
+         return;
+      }
 
       // Draw errors in a new bitmap
       var bmp = new Bitmap(metadata.width, metadata.height);
@@ -1969,6 +1974,11 @@ function ImageSolver()
    this.DrawDistortions = function(targetWindow, metadata)
    {
       console.writeln("Creating distortion map");
+      if (metadata.width * metadata.height * 4 >= 2 * 1024 * 1024 * 1024)
+      {
+         console.warningln("Cannot draw the image: The size is too big");
+         return;
+      }
 
       var ref_I_G_lineal = metadata.ref_I_G_lineal;
       if(metadata.controlPoints){

--- a/src/scripts/AdP/ImageSolver.js
+++ b/src/scripts/AdP/ImageSolver.js
@@ -30,6 +30,11 @@
 /*
    Changelog:
 
+   4.2.1: * When solving a list of files the seed parameters for each image are now set with the following priority:
+            (1) The previous astrometric solution (if it exists)
+            (2) The keywords OBJCTRA, OBJCTDEC, FOCALLEN and XPIXSZ
+            (3) The values in the "Image parameters" section of the configuration dialog.
+
    4.2:   * Use downloaded catalogs
 
    4.1.1: * Added support for XISF files
@@ -178,7 +183,7 @@
 #include <pjsr/SectionBar.jsh>
 #endif
 
-#define SOLVERVERSION "4.2"
+#define SOLVERVERSION "4.2.1"
 
 #ifndef USE_SOLVER_LIBRARY
 #define TITLE "Image Solver"
@@ -2830,6 +2835,14 @@ function main()
                console.writeln("\n*******************************")
                console.writeln("Processing image ", filePath);
                fileWindow = ImageWindow.open(filePath)[0];
+               if(!fileWindow){
+                  errorList.push({
+                     id:File.extractNameAndExtension(filePath),
+                     message: "The file could not be opened"
+                  });
+                  continue;
+               }
+               solver.Init(fileWindow, false);
                solver.metadata.width = fileWindow.mainView.image.width;
                solver.metadata.height = fileWindow.mainView.image.height;
                if (solver.SolveImage(fileWindow))
@@ -2861,10 +2874,11 @@ function main()
          }
 
          console.writeln("");
-         if(errorList.length > 0)
+         if(errorList.length > 0){
+            console.warningln("Process finished with errors:");
             for (var i = 0; i < errorList.length; i++)
-               console.writeln(errorList[i].id + ": " + errorList[i].message);
-         else
+               console.criticalln("  "+ errorList[i].id + ": " + errorList[i].message);
+         } else
             console.writeln("Process finished without errors");
       }
    }

--- a/src/scripts/AdP/ManualImageSolver.js
+++ b/src/scripts/AdP/ManualImageSolver.js
@@ -470,6 +470,13 @@ function ManualImageSolverEngine()
 
    this.DrawErrors = function (result)
    {
+      console.writeln("Creating error map");
+      if (result.metadata.width * result.metadata.height * 4 >= 2 * 1024 * 1024 * 1024)
+      {
+         console.warningln("Cannot draw the image: The size is too big");
+         return;
+      }
+
       // Draw errors in a new bitmap
       var bmp = new Bitmap(result.metadata.width, result.metadata.height);
 
@@ -534,6 +541,11 @@ function ManualImageSolverEngine()
    this.DrawDistortions = function(metadata)
    {
       console.writeln("Creating distortion map");
+      if (metadata.width * metadata.height * 4 >= 2 * 1024 * 1024 * 1024)
+      {
+         console.warningln("Cannot draw the image: The size is too big");
+         return;
+      }
 
       var ref_I_G_lineal = metadata.ref_I_G_lineal;
       if(metadata.controlPoints){

--- a/src/scripts/AdP/MosaicPlanner.js
+++ b/src/scripts/AdP/MosaicPlanner.js
@@ -30,6 +30,8 @@
 /*
  Changelog:
 
+ 1.2.1:* Added test for too big images (>0.5GigaPixels)
+
  1.2:  * Use downloaded catalogs
 
  1.1.1:* Fixed: The script didn't include two files
@@ -62,7 +64,7 @@
 #endif
 
 
-#define VERSION "1.2"
+#define VERSION "1.2.1"
 #define TITLE "Mosaic Planner"
 #define SETTINGS_MODULE "MosaicPlan"
 #define STAR_CSV_FILE   File.systemTempDirectory + "/stars.csv"
@@ -1667,6 +1669,9 @@ function MosaicPlannerEngine()
       if (this.metadata.ref_I_G == null)
          throw Error("The image has not WCS coordinates");
 
+      if (this.metadata.width * this.metadata.height * 4 >= 2 * 1024 * 1024 * 1024)
+         throw Error("The script can not work with images bigger than 536,870,912 pixels");
+
       if (this.showGuideStars)
          this.LoadCatalog();
    };
@@ -1852,6 +1857,13 @@ function MosaicPlannerEngine()
       var width = this.imageWindow.mainView.image.width;
       var height = this.imageWindow.mainView.image.height;
 
+      console.writeln("Rendering mosaic plan");
+      if (width * height * 4 >= 2 * 1024 * 1024 * 1024)
+      {
+         console.warningln("Cannot draw the image: The size is too big");
+         return;
+      }
+
       var bmp = new Bitmap(width, height);
       var imageOrg = this.imageWindow.mainView.image;
       var tmpW = new ImageWindow(width, height, imageOrg.numberOfChannels, this.imageWindow.bitsPerSample, this.imageWindow.isFloatSample, imageOrg.isColor, "MosaicPlan");
@@ -1866,8 +1878,8 @@ function MosaicPlannerEngine()
 
       this.PaintGuideStars(g);
 
-      console.writeln("Rendering mosaic plan");
       this.PaintTiles(g);
+
       g.end();
 
       var newid = "Mosaic_Plan";

--- a/src/scripts/AdP/Projections.js
+++ b/src/scripts/AdP/Projections.js
@@ -188,7 +188,7 @@ function ProjectionZenithalEqualArea()
       var y = (np1.y + np2.y) / 2;
       var dist = Math.min(Math.abs(np1.x - np2.x - 360) % 360, Math.abs(np1.x - np2.x + 360) % 360);
       return dist < DMath.sin(45 + y / 2) * 180;
-   }
+   };
 }
 ProjectionZenithalEqualArea.prototype = new ProjectionZenithalBase();
 

--- a/src/scripts/AdP/WCSmetadata.jsh
+++ b/src/scripts/AdP/WCSmetadata.jsh
@@ -464,6 +464,9 @@ function ImageMetadata(module)
       this.epoch = wcs.epoch;
       this.width = window.mainView.image.width;
       this.height = window.mainView.image.height;
+      this.ref_I_G_lineal = null;
+      this.ref_I_G = null;
+      this.ref_G_I = null;
 
       if (wcs.ctype1 && wcs.ctype1.substr(0, 5) == "'RA--" &&
          wcs.ctype2 && wcs.ctype2.substr(0, 5) == "'DEC-" &&


### PR DESCRIPTION
http://pixinsight.com/forum/index.php?topic=10290.0
When solving a list of files the seed parameters for each image are now set with the following priority:
(1) The previous astrometric solution (if it exists)
(2) The keywords OBJCTRA, OBJCTDEC, FOCALLEN and XPIXSZ
(3) The values in the "Image parameters" section of the configuration dialog.
