### PR TITLE
Add minimum/maximum properties for SNRWeight, Eccentricity, FWHM to SubframeSelector

### DIFF
--- a/src/scripts/mschuster/SubframeSelector/SubframeSelector.js
+++ b/src/scripts/mschuster/SubframeSelector/SubframeSelector.js
@@ -711,6 +711,7 @@ function tabulationEvaluate(dialog) {
    parameters.evaluationsDescriptions = evaluationsDescriptions;
 
    var evaluationsDescriptions = [];
+   var descriptionStatistics = generateEvaluationDescriptionStatistics(parameters.evaluationsDescriptions);
    for (var i = 0; i != parameters.evaluationsDescriptions.length; ++i) {
       var description = parameters.evaluationsDescriptions[i];
 
@@ -720,7 +721,8 @@ function tabulationEvaluate(dialog) {
          parameters.evaluationsDescriptions,
          parameters.actualSubframeScale(),
          parameters.actualCameraGain(),
-         parameters.cameraResolutionValues[parameters.cameraResolution]
+         parameters.cameraResolutionValues[parameters.cameraResolution],
+         descriptionStatistics
       );
       var weight = weightEvaluator.evaluate();
       if (weight != null) {
@@ -732,6 +734,7 @@ function tabulationEvaluate(dialog) {
    parameters.evaluationsDescriptions = evaluationsDescriptions;
 
    var evaluationsDescriptions = [];
+   var descriptionStatistics = generateEvaluationDescriptionStatistics(parameters.evaluationsDescriptions);
    for (var i = 0; i != parameters.evaluationsDescriptions.length; ++i) {
       var description = parameters.evaluationsDescriptions[i];
 
@@ -741,7 +744,8 @@ function tabulationEvaluate(dialog) {
          parameters.evaluationsDescriptions,
          parameters.actualSubframeScale(),
          parameters.actualCameraGain(),
-         parameters.cameraResolutionValues[parameters.cameraResolution]
+         parameters.cameraResolutionValues[parameters.cameraResolution],
+         descriptionStatistics
       );
       var checked = selectorEvaluator.evaluate();
       if (checked != null && !description.locked) {

--- a/src/scripts/mschuster/SubframeSelector/SubframeSelectorEditDialog.js
+++ b/src/scripts/mschuster/SubframeSelector/SubframeSelectorEditDialog.js
@@ -86,8 +86,9 @@ function editSelectorExpressionDialogPrototype() {
 "<i>weighting</i> | true | false | [ ! ] (<i>approval</i>) ]<br>" +
 "<i>weighting</i> = <i>term</i> [ [ + | - | * | / | ^ ] <i>term</i> ]...<br>" +
 "<i>term</i> = [ - ] [ <i>number</i> | <i>property</i> | (<i>weighting</i>) ]<br>" +
-"<i>property</i> = [ Index | Weight | WeightSigma | FWHM | FWHMSigma | Eccentricity | " +
-"EccentricitySigma | SNRWeight | SNRWeightSigma | Median | MedianSigma | " +
+"<i>property</i> = [ Index | Weight | WeightSigma | FWHM | FWHMSigma | FWHMMaximum | FWHMMinimum | " +
+"Eccentricity | EccentricitySigma | EccentricityMaximum | EccentricityMinimum | " +
+"SNRWeight | SNRWeightSigma | SNRWeightMaximum | SNRWeightMinimum | Median | MedianSigma | " +
 "MeanDeviation | MeanDeviationSigma | Noise | NoiseSigma | StarSupport | " +
 "StarSupportSigma | StarResidual | StarResidualSigma | NoiseSupport | " +
 "NoiseSupportSigma | FWHMMeanDev | FWHMMeanDevSigma | EccentricityMeanDev | " +
@@ -108,7 +109,8 @@ function editSelectorExpressionDialogPrototype() {
                [nullEvaluationDescription],
                parameters.actualSubframeScale(),
                parameters.actualCameraGain(),
-               parameters.cameraResolutionValues[parameters.cameraResolution]
+               parameters.cameraResolutionValues[parameters.cameraResolution],
+               nullEvaluationDescriptionStatistics
             );
             selectorEvaluator.evaluate();
             if (selectorEvaluator.error != null) {
@@ -212,8 +214,9 @@ function editWeightingExpressionDialogPrototype() {
 "properties. A blank expression will assign a zero weight to all subframes.</p>" +
 "<i>weighting</i> = [ <i>term</i> [ [ + | - | * | / | ^ ] <i>term</i> ]... ]<br>" +
 "<i>term</i> = [ - ] [ <i>number</i> | <i>property</i> | (<i>weighting</i>) ]<br>" +
-"<i>property</i> = [ Index | FWHM | FWHMSigma | Eccentricity | EccentricitySigma | " +
-"SNRWeight | SNRWeightSigma | Median | MedianSigma | MeanDeviation | " +
+"<i>property</i> = [ Index | FWHM | FWHMSigma | FWHMMaximum | FWHMMinimum | " +
+"Eccentricity | EccentricitySigma | EccentricityMaximum | EccentricityMinimum | " +
+"SNRWeight | SNRWeightSigma | SNRWeightMaximum | SNRWeightMinimum | Median | MedianSigma | MeanDeviation | " +
 "MeanDeviationSigma | Noise | NoiseSigma | StarSupport | StarSupportSigma | " +
 "StarResidual | StarResidualSigma | NoiseSupport | NoiseSupportSigma | FWHMMeanDev | " +
 "FWHMMeanDevSigma | EccentricityMeanDev | EccentricityMeanDevSigma | " +
@@ -234,7 +237,8 @@ function editWeightingExpressionDialogPrototype() {
                [nullEvaluationDescription],
                parameters.actualSubframeScale(),
                parameters.actualCameraGain(),
-               parameters.cameraResolutionValues[parameters.cameraResolution]
+               parameters.cameraResolutionValues[parameters.cameraResolution],
+               nullEvaluationDescriptionStatistics
             );
             weightEvaluator.evaluate();
             if (weightEvaluator.error != null) {

--- a/src/scripts/mschuster/SubframeSelector/SubframeSelectorEvaluator.js
+++ b/src/scripts/mschuster/SubframeSelector/SubframeSelectorEvaluator.js
@@ -204,7 +204,7 @@ function findMedianDispersionDescription(descriptions) {
 }
 
 function selectorExpressionEvaluator(
-   expression, description, descriptions, subframeScale, cameraGain, cameraResolution
+   expression, description, descriptions, subframeScale, cameraGain, cameraResolution, statistics
 ) {
    this.expression = expression;
    this.description = description;
@@ -380,6 +380,12 @@ function selectorExpressionEvaluator(
       else if (property == "FWHM") {
          return this.subframeScale * this.description.FWHM;
       }
+      else if (property == "FWHMMaximum") {
+         return this.subframeScale * statistics.FWHMMaximum;
+      }
+      else if (property == "FWHMMinimum") {
+         return this.subframeScale * statistics.FWHMMinimum;
+      }
       else if (property == "FWHMSigma") {
          value = this.subframeScale * this.description.FWHM;
          medianDispersion = this.scaleMedianDispersion(
@@ -400,6 +406,12 @@ function selectorExpressionEvaluator(
       else if (property == "Eccentricity") {
          return this.description.eccentricity;
       }
+      else if (property == "EccentricityMaximum") {
+         return statistics.eccentricityMaximum;
+      }
+      else if (property == "EccentricityMinimum") {
+         return statistics.eccentricityMinimum;
+      }
       else if (property == "EccentricitySigma") {
          value = this.description.eccentricity;
          medianDispersion = this.medianDispersionDescription.eccentricity;
@@ -415,6 +427,12 @@ function selectorExpressionEvaluator(
       }
       else if (property == "SNRWeight") {
          return this.description.SNRWeight;
+      }
+      else if (property == "SNRWeightMaximum") {
+         return statistics.SNRWeightMaximum;
+      }
+      else if (property == "SNRWeightMinimum") {
+         return statistics.SNRWeightMinimum;
       }
       else if (property == "SNRWeightSigma") {
          value = this.description.SNRWeight;
@@ -753,7 +771,7 @@ function selectorExpressionEvaluator(
 }
 
 function weightingExpressionEvaluator(
-   expression, description, descriptions, subframeScale, cameraGain, cameraResolution
+   expression, description, descriptions, subframeScale, cameraGain, cameraResolution, statistics
 ) {
    this.expression = expression;
    this.description = description;
@@ -920,6 +938,12 @@ function weightingExpressionEvaluator(
       else if (property == "FWHM") {
          return this.subframeScale * this.description.FWHM;
       }
+      else if (property == "FWHMMaximum") {
+         return this.subframeScale * statistics.FWHMMaximum;
+      }
+      else if (property == "FWHMMinimum") {
+         return this.subframeScale * statistics.FWHMMinimum;
+      }
       else if (property == "FWHMSigma") {
          value = this.subframeScale * this.description.FWHM;
          medianDispersion = this.scaleMedianDispersion(
@@ -940,6 +964,12 @@ function weightingExpressionEvaluator(
       else if (property == "Eccentricity") {
          return this.description.eccentricity;
       }
+      else if (property == "EccentricityMaximum") {
+         return statistics.eccentricityMaximum;
+      }
+      else if (property == "EccentricityMinimum") {
+         return statistics.eccentricityMinimum;
+      }
       else if (property == "EccentricitySigma") {
          value = this.description.eccentricity;
          medianDispersion = this.medianDispersionDescription.eccentricity;
@@ -955,6 +985,12 @@ function weightingExpressionEvaluator(
       }
       else if (property == "SNRWeight") {
          return this.description.SNRWeight;
+      }
+      else if (property == "SNRWeightMaximum") {
+         return statistics.SNRWeightMaximum;
+      }
+      else if (property == "SNRWeightMinimum") {
+         return statistics.SNRWeightMinimum;
       }
       else if (property == "SNRWeightSigma") {
          value = this.description.SNRWeight;
@@ -1139,7 +1175,8 @@ function selectorExpressionIsValid(expression) {
       [nullEvaluationDescription],
       parameters.actualSubframeScale(),
       parameters.actualCameraGain(),
-      parameters.cameraResolutionValues[parameters.cameraResolution]
+      parameters.cameraResolutionValues[parameters.cameraResolution],
+      nullEvaluationDescriptionStatistics
    );
    selectorEvaluator.evaluate();
    return selectorEvaluator.error == null;
@@ -1152,7 +1189,8 @@ function weightingExpressionIsValid(expression) {
       [nullEvaluationDescription],
       parameters.actualSubframeScale(),
       parameters.actualCameraGain(),
-      parameters.cameraResolutionValues[parameters.cameraResolution]
+      parameters.cameraResolutionValues[parameters.cameraResolution],
+      nullEvaluationDescriptionStatistics
    );
    weightEvaluator.evaluate();
    return weightEvaluator.error == null;

--- a/src/scripts/mschuster/SubframeSelector/SubframeSelectorSubframeDescription.js
+++ b/src/scripts/mschuster/SubframeSelector/SubframeSelectorSubframeDescription.js
@@ -352,6 +352,30 @@ var evaluationDescriptionCompare = [
    ]
 ];
 
+function evaluationDescriptionStatistics() {
+   this.FWHMMinimum = Number.MAX_VALUE;
+   this.FWHMMaximum = Number.MIN_VALUE;
+   this.eccentricityMinimum = Number.MAX_VALUE;
+   this.eccentricityMaximum = Number.MIN_VALUE;
+   this.SNRWeightMinimum = Number.MAX_VALUE;
+   this.SNRWeightMaximum = Number.MIN_VALUE;
+}
+
+function generateEvaluationDescriptionStatistics(evaluationDescriptions) {
+   var statistics = new evaluationDescriptionStatistics();
+   evaluationDescriptions.forEach(function(description) {
+      if (description.FWHM < statistics.FWHMMinimum) statistics.FWHMMinimum = description.FWHM;
+      if (description.FWHM > statistics.FWHMMaximum) statistics.FWHMMaximum = description.FWHM;
+      if (description.eccentricity < statistics.eccentricityMinimum) statistics.eccentricityMinimum = description.eccentricity;
+      if (description.eccentricity > statistics.eccentricityMaximum) statistics.eccentricityMaximum = description.eccentricity;
+      if (description.SNRWeight < statistics.SNRWeightMinimum) statistics.SNRWeightMinimum = description.SNRWeight;
+      if (description.SNRWeight > statistics.SNRWeightMaximum) statistics.SNRWeightMaximum = description.SNRWeight;
+   });
+   return statistics;
+}
+
+var nullEvaluationDescriptionStatistics = new evaluationDescriptionStatistics();
+
 function SNRWeightFunction(meanDeviation, noise, cameraGain, cameraResolution) {
    return noise != 0 ? Math.pow(meanDeviation, 2.0) / Math.pow(noise, 2.0) : 0;
 }


### PR DESCRIPTION
I'm not sure what the proper procedure is, but I added a little bit of functionality to the SubframeSelector script to recognize new keywords.  I got tired of sorting images and editing the selection/approval formulas for each batch of images, so I introduced six new keywords to make my formulas essentially constant.

Let me know if patches like this are welcome and I will send them along as I make them.  If not, no hard feelings...