### PR TITLE
SDSS9, SDSS7 and units of aperture size

### DIFF
--- a/src/scripts/AdP/AstronomicalCatalogs.jsh
+++ b/src/scripts/AdP/AstronomicalCatalogs.jsh
@@ -3,7 +3,7 @@
 
    This file is part of ImageSolver and AnnotateImage scripts
 
-   Copyright (C) 2012-2014, Andres del Pozo
+   Copyright (C) 2012-2017, Andres del Pozo
    All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
@@ -1671,15 +1671,12 @@ BVCatalog.prototype = new VizierCatalog;
 __catalogRegister__.Register( new BVCatalog );
 
 // ******************************************************************
-// SDSSCatalog
+// SDSSBase: Base class of SDSS catalog versions
 // ******************************************************************
-function SDSSCatalog()
+function SDSSBase(catalogName)
 {
-   this.name="SDSS";
-   this.description = "SDSS R8 catalog (469,053,874 objects)";
-
    this.__base__ = VizierCatalog;
-   this.__base__( this.name );
+   this.__base__( catalogName );
 
    this.catalogMagnitude = 25;
 
@@ -1694,11 +1691,6 @@ function SDSSCatalog()
    this.magnitudeFilter = "rmag";
    this.classFilter = 0;
    this.maxFov = 45;
-
-   this.GetConstructor = function()
-   {
-      return "new SDSSCatalog()";
-   }
 
    this._base_GetEditControls = this.GetEditControls;
    this.GetEditControls = function (parent)
@@ -1739,12 +1731,12 @@ function SDSSCatalog()
 
    this.UrlBuilder = function(center, fov, mirrorServer)
    {
-      var url=mirrorServer+"viz-bin/asu-tsv?-source=II/306/sdss8&mode==1&-c=" +
+      var url=mirrorServer+"viz-bin/asu-tsv?-source="+this.vizierSource+"&mode==1&-c=" +
          format("%f %f",center.x, center.y) +
          "&-c.r=" + format("%f",fov) +
          "&-c.u=deg&-out.form=|"+
          format("&-out.max=%d", this.maxRecords)+
-         "&-out=SDSS8&-out=RAJ2000&-out=DEJ2000&-out=pmRA&-out=pmDE&-out=cl&-out=zsp" +
+         "&-out="+this.idField+"&-out=RAJ2000&-out=DEJ2000&-out=pmRA&-out=pmDE&-out=cl&-out=zsp" +
          "&-out=umag&-out=gmag&-out=rmag&-out=imag&-out=zmag" +
          this.CreateMagFilter( this.magnitudeFilter, this.magMin, this.magMax ) ;
       if( this.classFilter==1 )
@@ -1783,7 +1775,7 @@ function SDSSCatalog()
             x += dx;
             y += dy;
          }
-         var record = new CatalogRecord( new Point( x, y ), 0, "SDSS8"+tokens[0].trim(), 0 );
+         var record = new CatalogRecord( new Point( x, y ), 0, "SDSS"+tokens[0].trim(), 0 );
          record.Redshift = tokens[6].trim();
          record.Class = tokens[5].trim();
          record.umag = tokens[7].trim();
@@ -1798,8 +1790,56 @@ function SDSSCatalog()
    }
 }
 
-SDSSCatalog.prototype=new VizierCatalog;
+SDSSBase.prototype=new VizierCatalog;
+
+
+// ******************************************************************
+// SDSSCatalog: Latest version of SDSS
+// ******************************************************************
+function SDSSCatalog()
+{
+   this.name="SDSS";
+   this.description = "SDSS R9 catalog (469,053,874 objects)";
+
+   this.__base__ = SDSSBase;
+   this.__base__( this.name );
+
+   this.vizierSource = "V/139"
+   this.idField = "SDSS9";
+
+   this.GetConstructor = function()
+   {
+      return "new SDSSCatalog()";
+   }
+}
+
+SDSSCatalog.prototype=new SDSSBase;
+
 __catalogRegister__.Register( new SDSSCatalog );
+
+// ******************************************************************
+// SDSS7Catalog: Release 7 of SDSS
+// ******************************************************************
+function SDSS7Catalog()
+{
+   this.name="SDSS7";
+   this.description = "SDSS R7 catalog (357,175,411 objects)";
+
+   this.__base__ = SDSSBase;
+   this.__base__( this.name );
+
+   this.vizierSource = "II/294"
+   this.idField = "SDSS";
+
+   this.GetConstructor = function()
+   {
+      return "new SDSS7Catalog()";
+   }
+}
+
+SDSS7Catalog.prototype=new SDSSBase;
+
+__catalogRegister__.Register( new SDSS7Catalog );
 
 // ******************************************************************
 // GSCCatalog

--- a/src/scripts/AdP/CircleSquareIntersect.js
+++ b/src/scripts/AdP/CircleSquareIntersect.js
@@ -3,7 +3,7 @@
 
  This file is part of the Photometry script
 
- Copyright (C) 2013, Andres del Pozo
+ Copyright (C) 2013-2017, Andres del Pozo
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -69,38 +69,60 @@ function CircleSquareIntersection(center, radius)
 
    this.ProcessCase0 = function ()
    {
-      // Test intersection
-      if(this.sqOrg.y<=0 && this.sqOrg.y+this.sqSize>=0)
+      // Check if the center of the circle is inside the square
+      if (this.sqOrg.x <= 0 && this.sqOrg.x + this.sqSize >= 0 && this.sqOrg.y <= 0 && this.sqOrg.y + this.sqSize >= 0)
       {
+         var area = Math.PI * this.radius2;
          // To the right
-         if(this.sqOrg.x<radius && this.sqOrg.x+this.sqSize>radius)
-         {
-            //console.writeln("A",radius-this.sqOrg.x);
-            return this.SegmentAreaBy_h(radius-this.sqOrg.x);
-         }
+         if (this.sqOrg.x > -radius)
+            area -= this.SegmentAreaBy_h(this.sqOrg.x + radius);
 
-         // To the left
-         if(this.sqOrg.x<-radius && this.sqOrg.x+this.sqSize>-radius)
-         {
-            //console.writeln("B",this.sqOrg.x+this.sqSize+radius);
-            return this.SegmentAreaBy_h(this.sqOrg.x+this.sqSize+radius);
-         }
+         if (this.sqOrg.x + this.sqSize < radius)
+            area -= this.SegmentAreaBy_h(radius - this.sqOrg.x - this.sqSize);
+
+         if (this.sqOrg.y > -radius)
+            area -= this.SegmentAreaBy_h(this.sqOrg.y + radius);
+
+         if (this.sqOrg.y + this.sqSize < radius)
+            area -= this.SegmentAreaBy_h(radius - this.sqOrg.y - this.sqSize);
+
+         return area;
       }
-
-      if(this.sqOrg.x<=0 && this.sqOrg.x+this.sqSize>=0)
+      else
       {
-         // To the botton
-         if(this.sqOrg.y<radius && this.sqOrg.y+this.sqSize>radius)
+         // Test intersection
+         if (this.sqOrg.y <= 0 && this.sqOrg.y + this.sqSize >= 0)
          {
-            //console.writeln("C",radius-this.sqOrg.y);
-            return this.SegmentAreaBy_h(radius-this.sqOrg.y);
+            // To the right
+            if (this.sqOrg.x < radius && this.sqOrg.x + this.sqSize > radius)
+            {
+               //console.writeln("A",radius-this.sqOrg.x);
+               return this.SegmentAreaBy_h(radius - this.sqOrg.x);
+            }
+
+            // To the left
+            if (this.sqOrg.x < -radius && this.sqOrg.x + this.sqSize > -radius)
+            {
+               //console.writeln("B",this.sqOrg.x+this.sqSize+radius);
+               return this.SegmentAreaBy_h(this.sqOrg.x + this.sqSize + radius);
+            }
          }
 
-         // To the top
-         if(this.sqOrg.y<-radius && this.sqOrg.y+this.sqSize>-radius)
+         if (this.sqOrg.x <= 0 && this.sqOrg.x + this.sqSize >= 0)
          {
-            //console.writeln("D",this.sqOrg.y+this.sqSize-radius);
-            return this.SegmentAreaBy_h(this.sqOrg.y+this.sqSize+radius);
+            // To the botton
+            if (this.sqOrg.y < radius && this.sqOrg.y + this.sqSize > radius)
+            {
+               //console.writeln("C",radius-this.sqOrg.y);
+               return this.SegmentAreaBy_h(radius - this.sqOrg.y);
+            }
+
+            // To the top
+            if (this.sqOrg.y < -radius && this.sqOrg.y + this.sqSize > -radius)
+            {
+               //console.writeln("D",this.sqOrg.y+this.sqSize-radius);
+               return this.SegmentAreaBy_h(this.sqOrg.y + this.sqSize + radius);
+            }
          }
       }
       return 0;
@@ -239,7 +261,7 @@ function CircleSquareIntersection(center, radius)
       var p3inside = this.CheckPointInCircle(new Point(this.sqOrg.x + this.sqSize, this.sqOrg.y + this.sqSize));
       var p4inside = this.CheckPointInCircle(new Point(this.sqOrg.x, this.sqOrg.y + this.sqSize));
       var numInside = p1inside + p2inside + p3inside + p4inside;
-      //console.writeln("Num corner inside: ", numInside);
+//      console.writeln("Num corner inside: ", numInside);
       var area=0;
       switch(numInside)
       {
@@ -295,43 +317,45 @@ function SquareSquareIntersection(center, size)
 
 function TestCircle()
 {
-   var engine=new CircleSquareIntersection();
+   var engine=null;
 
    // Case 0 - Out
    console.writeln("Case 0 - Out");
-   engine.SetCircle(new Point(0,0), 5);
-   engine.SetSquare(new Point(6,0), 2);
-   console.writeln("Area=",engine.Calculate());
+   engine=new CircleSquareIntersection(new Point(0,0), 5);
+   console.writeln("Area=",engine.Calculate(new Point(6,0), 2));
 
    // Case 0 - Intersect
    console.writeln("Case 0 - Intersect");
-   engine.SetCircle(new Point(0,0), 5);
-   engine.SetSquare(new Point(4.99,-1), 2);
-   console.writeln("Area=",engine.Calculate());
+   engine=new CircleSquareIntersection(new Point(0,0), 5);
+   console.writeln("Area=",engine.Calculate(new Point(4.99,-1), 2));
 
    // Case 1
    console.writeln("Case 1");
-   engine.SetCircle(new Point(0,0), 5);
-   engine.SetSquare(new Point(4,2), 2);
-   console.writeln("Area=",engine.Calculate());
+   engine=new CircleSquareIntersection(new Point(0,0), 5);
+   console.writeln("Area=",engine.Calculate(new Point(4,2), 2));
 
    // Case 2
    console.writeln("Case 2");
-   engine.SetCircle(new Point(0,0), 5);
-   engine.SetSquare(new Point(3,1), 2);
-   console.writeln("Area=",engine.Calculate());
+   engine=new CircleSquareIntersection(new Point(0,0), 5);
+   console.writeln("Area=",engine.Calculate(new Point(3,1), 2));
 
    // Case 3
    console.writeln("Case 3");
-   engine.SetCircle(new Point(0,0), 5);
-   engine.SetSquare(new Point(2,2), 2);
-   console.writeln("Area=",engine.Calculate());
+   engine=new CircleSquareIntersection(new Point(0,0), 5);
+   console.writeln("Area=",engine.Calculate(new Point(2,2), 2));
 
    // Case 4
    console.writeln("Case 4");
-   engine.SetCircle(new Point(0,0), 5);
-   engine.SetSquare(new Point(1,1), 2);
-   console.writeln("Area=",engine.Calculate());
+   engine=new CircleSquareIntersection(new Point(0,0), 5);
+   console.writeln("Area=",engine.Calculate(new Point(1,1), 2));
+
+   console.writeln("Case 5");
+   engine=new CircleSquareIntersection(new Point(0,0), 0.5);
+   console.writeln("Area=",engine.Calculate(new Point(-0.5, -0.5), 1));
+
+   console.writeln("Case 6");
+   engine=new CircleSquareIntersection(new Point(0,0), 1);
+   console.writeln("Area=",engine.Calculate(new Point(0, -0.5), 1));
 
    // Coverage
    console.writeln("Coverage");
@@ -339,15 +363,14 @@ function TestCircle()
    var cell=1;
    var totalArea=0;
    var center=new Point (3179.403267,3568.977920);
-   engine.SetCircle(center, rad);
-engine.SetSquare(new Point(3179,3566), 1);
-console.writeln(engine.Calculate());
+   engine = new CircleSquareIntersection(center, rad);
+//engine.SetSquare(new Point(3179,3566), 1);
+//console.writeln(engine.Calculate());
    for(var y=Math.floor(center.y-rad); y<center.y+rad; y+=cell)
    {
       for(var x=Math.floor(center.x-rad); x<center.x+rad; x+=cell)
       {
-         engine.SetSquare(new Point(x,y), cell);
-         var area=engine.Calculate();
+         var area=engine.Calculate(new Point(x,y), cell);
          totalArea+=area;
          console.writeln(format("[%f,%f]=%f ",x,y,area));
       }


### PR DESCRIPTION
Updated the SDSS catalog to release 9 and added SDSS-DR7.
AperturePhotometry: 
   * Added selection of the units of the aperture: pixels or arcseconds
   * Added support and warning for apertures less that 2 pixels