### PR TITLE
Return outputSuffix. Add CCD-TEMP keyword into integrated file

### DIFF
--- a/src/scripts/BatchPreprocessing/BatchPreprocessing-global.js
+++ b/src/scripts/BatchPreprocessing/BatchPreprocessing-global.js
@@ -62,6 +62,7 @@
 var ImageType = { UNKNOWN : -1, BIAS : 0, DARK : 1, FLAT : 2, LIGHT : 3 };
 
 // Default parameters
+#define DEFAULT_OUTPUT_SUFFIX                ".xisf"
 #define DEFAULT_OUTPUT_DIRECTORY             ""
 #define DEFAULT_CFA_IMAGES                   false
 #define DEFAULT_UP_BOTTOM_FITS               true


### PR DESCRIPTION
Hi.

As discuss here https://pixinsight.com/forum/index.php?topic=11600.0 , add CCD-TEMP into integrated file. For example masterDark integration from few -20C darks:

IMAGETYP= 'Master Dark'        / Type of image
CCD-TEMP=                 -20. / Averate ccd-temperature
....

Also Juan. You forgot to support other formats except xisf. I return outputSuffix and ability to fast change suffix in *general.js file. Please be so kind to think about fit-files user like me. I want to use your Greate PixInsight, but at work MUST to use FIT. Ok? :)